### PR TITLE
Fix stage 2 training script for repository environment

### DIFF
--- a/fine_tuning.py
+++ b/fine_tuning.py
@@ -313,7 +313,7 @@ if __name__ == '__main__':
 
     # Only add NON-conflicting flags:
     parser.add_argument('--labels', dest='labels', type=str, required=True, help="CSV with video,pose,text")
-    parser.add_argument('--output_dir', type=str, required=True, help="Output directory")  # use canonical name
+    # Reuse existing --output_dir from base parser (utils.get_args_parser())
     parser.add_argument('--stage', type=int, default=2)  # accepted, not used for branching
     parser.add_argument('--device', default='cuda')      # accepted, not used
 

--- a/script/train_stage2.sh
+++ b/script/train_stage2.sh
@@ -1,22 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$HOME/projects/dev/inverse"
+# Resolve repository root relative to this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT"
 
-POSE_ROOT="$ROOT/data/WLBSL/pose_format"
-LABELS="$ROOT/data/WLBSL/WLBSL_Labels.csv"
-SAVE="$ROOT/checkpoints/wlbs_stage2_words"
+# Allow overriding via environment variables but provide sensible defaults
+LABELS="${LABELS:-$ROOT/data/WLBSL/WLBSL_Labels.csv}"
+SAVE="${SAVE:-$ROOT/checkpoints/wlbs_stage2_words}"
 FINETUNE="${FINETUNE:-$ROOT/checkpoints/pretrain_wlbs/best.pt}"   # override if different
+
 mkdir -p "$SAVE"
 
 ARGS=(
   --stage 2
   --task ISLR
   --dataset WLASL
-  --pose-root "$POSE_ROOT"
-  --labels    "$LABELS"
-  --save-dir  "$SAVE"
+  --labels     "$LABELS"
+  --output_dir "$SAVE"
   --device    cuda
 )
 
@@ -27,5 +29,5 @@ else
   echo "⚠️  FINETUNE not found at: $FINETUNE — training Stage-2 from scratch."
 fi
 
-PYTHONPATH="$ROOT:$PYTHONPATH" CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}" \
+PYTHONPATH="$ROOT:${PYTHONPATH:-}" CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}" \
 python3 fine_tuning.py "${ARGS[@]}"


### PR DESCRIPTION
## Summary
- resolve repo root dynamically in stage2 script
- allow overriding dataset and checkpoint paths via env vars
- avoid argparse conflicts and standardize to --output_dir

## Testing
- `pip install torch==2.2.2+cpu torchvision==0.17.2+cpu torchaudio==2.2.2+cpu timm transformers einops deepspeed`  
- `bash script/train_stage2.sh` *(fails: ModuleNotFoundError: No module named 'distutils')*


------
https://chatgpt.com/codex/tasks/task_e_68a30dc39388832eb95866ec16d42e87