### PR TITLE
Fix stage 2 training script for repository environment

### DIFF
--- a/fine_tuning.py
+++ b/fine_tuning.py
@@ -313,7 +313,7 @@ if __name__ == '__main__':
 
     # Only add NON-conflicting flags:
     parser.add_argument('--labels', dest='labels', type=str, required=True, help="CSV with video,pose,text")
-    parser.add_argument('--output_dir', type=str, required=True, help="Output directory")  # use canonical name
+    # Reuse existing --output_dir from base parser (utils.get_args_parser())
     parser.add_argument('--stage', type=int, default=2)  # accepted, not used for branching
     parser.add_argument('--device', default='cuda')      # accepted, not used
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy==1.22.4
+setuptools>=65
 scipy==1.7.3
 pandas==1.3.5
 scikit-learn==1.0.2

--- a/script/train_stage2.sh
+++ b/script/train_stage2.sh
@@ -1,22 +1,40 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$HOME/projects/dev/inverse"
+# Ensure distutils is available (Python 3.12+ drops it)
+python3 - <<'PY'
+import importlib.util, subprocess, sys
+if importlib.util.find_spec('distutils') is None:
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'setuptools'])
+req = ['torch', 'torchvision', 'torchaudio', 'timm', 'transformers', 'einops', 'deepspeed']
+missing = [r for r in req if importlib.util.find_spec(r) is None]
+if missing:
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', *missing])
+PY
+
+# Resolve repository root relative to this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT"
 
-POSE_ROOT="$ROOT/data/WLBSL/pose_format"
-LABELS="$ROOT/data/WLBSL/WLBSL_Labels.csv"
-SAVE="$ROOT/checkpoints/wlbs_stage2_words"
+# Allow overriding via environment variables but provide sensible defaults
+LABELS="${LABELS:-$ROOT/data/WLBSL/WLBSL_Labels.csv}"
+SAVE="${SAVE:-$ROOT/checkpoints/wlbs_stage2_words}"
 FINETUNE="${FINETUNE:-$ROOT/checkpoints/pretrain_wlbs/best.pt}"   # override if different
+
 mkdir -p "$SAVE"
+
+if [[ ! -f "$LABELS" ]]; then
+  echo "❌  Labels CSV not found at: $LABELS" >&2
+  exit 1
+fi
 
 ARGS=(
   --stage 2
   --task ISLR
   --dataset WLASL
-  --pose-root "$POSE_ROOT"
-  --labels    "$LABELS"
-  --save-dir  "$SAVE"
+  --labels     "$LABELS"
+  --output_dir "$SAVE"
   --device    cuda
 )
 
@@ -27,5 +45,5 @@ else
   echo "⚠️  FINETUNE not found at: $FINETUNE — training Stage-2 from scratch."
 fi
 
-PYTHONPATH="$ROOT:$PYTHONPATH" CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}" \
+PYTHONPATH="$ROOT:${PYTHONPATH:-}" CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}" \
 python3 fine_tuning.py "${ARGS[@]}"


### PR DESCRIPTION
## Summary
- ensure `distutils` replacement and core training libraries are installed at runtime
- verify labels CSV exists before launching Stage-2 finetuning

## Testing
- `ssh openai@34.91.36.176` *(network unreachable)*
- `bash script/train_stage2.sh` *(fails: KeyboardInterrupt during dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68a30dc39388832eb95866ec16d42e87