### PR TITLE
Include mpi4py dependency and fix DeepSpeed unwrap for stage-2 training

### DIFF
--- a/fine_tuning.py
+++ b/fine_tuning.py
@@ -255,7 +255,10 @@ def main(args):
     )
 
     model, optimizer, lr_scheduler = utils.init_deepspeed(args, model, optimizer, lr_scheduler)
-    model_without_ddp = model.module.module
+    if args.distributed:
+        model_without_ddp = model.module.module
+    else:
+        model_without_ddp = model.module
     print(optimizer)
 
     output_dir = Path(args.output_dir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ decord==0.6.0
 timm==0.8.10.dev0
 accelerate==0.29.2
 einops==0.6.1
+mpi4py==4.1.0
 
 matplotlib==3.4.3
 seaborn==0.12.1

--- a/script/train_stage2.sh
+++ b/script/train_stage2.sh
@@ -6,7 +6,10 @@ python3 - <<'PY'
 import importlib.util, subprocess, sys
 if importlib.util.find_spec('distutils') is None:
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'setuptools'])
-req = ['torch', 'torchvision', 'torchaudio', 'timm', 'transformers', 'einops', 'deepspeed']
+# Base python packages required for stage-2 fine-tuning. ``mpi4py`` is
+# needed by DeepSpeed for its distributed initialisation even when using a
+# single GPU.
+req = ['torch', 'torchvision', 'torchaudio', 'timm', 'transformers', 'einops', 'deepspeed', 'mpi4py']
 missing = [r for r in req if importlib.util.find_spec(r) is None]
 if missing:
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', *missing])


### PR DESCRIPTION
## Summary
- ensure `train_stage2.sh` installs mpi4py for DeepSpeed
- add mpi4py to project requirements
- handle DeepSpeed model unwrapping in `fine_tuning.py` when not using DDP

## Testing
- `bash -n script/train_stage2.sh`
- `python -m py_compile fine_tuning.py`
- `python fine_tuning.py --help` *(fails: operator `torchvision::nms` does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a31ea1089c832eb1b60a5e3cd68596