### PR TITLE
Include mpi4py dependency and fix DeepSpeed unwrap for stage-2 training

### DIFF
--- a/fine_tuning.py
+++ b/fine_tuning.py
@@ -119,13 +119,24 @@ class WLBSL_ISLR_Dataset(Dataset):
         src_list, tgt_list = zip(*batch)
         poses = [b["pose"] for b in src_list]
         lens  = torch.stack([b["pose_len"] for b in src_list], dim=0)
-        flat  = [p.reshape(p.shape[0], -1) for p in poses]              # [T, J*C]
-        pad_flat = pad_sequence(flat, batch_first=True, padding_value=0.0)  # [B, T, J*C]
+
+        # Pad to [B, T, J, C]
+        pad_pose = pad_sequence(poses, batch_first=True, padding_value=0.0)
+        B, max_len, J, C = pad_pose.shape
+
+        # Split joints into body/hand/face parts assuming fixed ordering
+        idx = 0
+        parts = {}
+        for name, n in [("body", 9), ("left", 21), ("right", 21), ("face_all", 18)]:
+            parts[name] = pad_pose[:, :, idx:idx + n, :]
+            idx += n
+
+        # Attention mask for valid timesteps
+        mask = torch.arange(max_len).expand(B, max_len) < lens.unsqueeze(1)
+
         src_input = {
-            "pose": pad_flat,
-            "pose_len": lens,
-            "max_len": torch.tensor(pad_flat.shape[1]).long(),
-            "jc": torch.tensor(pad_flat.shape[2]).long(),
+            **parts,
+            "attention_mask": mask.long(),
         }
         tgt_input = {"gt_sentence": [b["gt_sentence"] for b in tgt_list]}
         return src_input, tgt_input
@@ -255,7 +266,10 @@ def main(args):
     )
 
     model, optimizer, lr_scheduler = utils.init_deepspeed(args, model, optimizer, lr_scheduler)
-    model_without_ddp = model.module.module
+    if args.distributed:
+        model_without_ddp = model.module.module
+    else:
+        model_without_ddp = model.module
     print(optimizer)
 
     output_dir = Path(args.output_dir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ decord==0.6.0
 timm==0.8.10.dev0
 accelerate==0.29.2
 einops==0.6.1
+mpi4py==4.1.0
 
 matplotlib==3.4.3
 seaborn==0.12.1

--- a/script/train_stage2.sh
+++ b/script/train_stage2.sh
@@ -6,7 +6,10 @@ python3 - <<'PY'
 import importlib.util, subprocess, sys
 if importlib.util.find_spec('distutils') is None:
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'setuptools'])
-req = ['torch', 'torchvision', 'torchaudio', 'timm', 'transformers', 'einops', 'deepspeed']
+# Base python packages required for stage-2 fine-tuning. ``mpi4py`` is
+# needed by DeepSpeed for its distributed initialisation even when using a
+# single GPU.
+req = ['torch', 'torchvision', 'torchaudio', 'timm', 'transformers', 'einops', 'deepspeed', 'mpi4py']
 missing = [r for r in req if importlib.util.find_spec(r) is None]
 if missing:
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', *missing])


### PR DESCRIPTION
## Summary
- ensure `train_stage2.sh` installs mpi4py for DeepSpeed
- add mpi4py to project requirements
- handle DeepSpeed model unwrapping in `fine_tuning.py` when not using DDP
- split collated pose tensors into body/hand/face segments with attention mask

## Testing
- `bash -n script/train_stage2.sh`
- `python -m py_compile fine_tuning.py`
- `python - <<'PY' ...` *(fails: ModuleNotFoundError: No module named 'deepspeed')*


------
https://chatgpt.com/codex/tasks/task_e_68a31ea1089c832eb1b60a5e3cd68596