### PR TITLE
Remove debug exit from training loop

### DIFF
--- a/fine_tuning.py
+++ b/fine_tuning.py
@@ -398,16 +398,6 @@ def train_one_epoch(args, model, data_loader, optimizer, epoch):
     for step, (src_input, tgt_input) in enumerate(metric_logger.log_every(data_loader, print_freq, header)):
         src_input = _maybe_cast_and_move(src_input, target_dtype)
 
-        if getattr(args, "probe_shapes", False) and step == 0 and utils.is_main_process():
-            print("== Incoming src_input shapes ==")
-            for k, v in src_input.items():
-                if isinstance(v, torch.Tensor):
-                    print(f"  {k}: {tuple(v.shape)} {v.dtype} {v.device}", flush=True)
-            import torch.distributed as dist
-            if dist.is_available() and dist.is_initialized():
-                dist.destroy_process_group()
-            raise SystemExit(0)
-
         stack_out = model(src_input, tgt_input)
         total_loss = stack_out['loss']
 


### PR DESCRIPTION
## Summary
- Remove temporary shape-probing block from `train_one_epoch` so the training loop iterates over the full dataloader

## Testing
- `bash script/train_stage2.sh` *(fails: Labels CSV not found at /workspace/inverse-machine-learning-ai/data/WLBSL/WLBSL_Labels.csv)*

------
https://chatgpt.com/codex/tasks/task_e_68a3871415f0832e92225ce5980f0886