### PR TITLE
Fix stage-2 training loop and script args

### DIFF
--- a/fine_tuning.py
+++ b/fine_tuning.py
@@ -398,24 +398,8 @@ def train_one_epoch(args, model, data_loader, optimizer, epoch):
     for step, (src_input, tgt_input) in enumerate(metric_logger.log_every(data_loader, print_freq, header)):
         src_input = _maybe_cast_and_move(src_input, target_dtype)
 
-        if getattr(args, "probe_shapes", False) and step == 0 and utils.is_main_process():
-            print("== Incoming src_input shapes ==")
-            for k, v in src_input.items():
-                if isinstance(v, torch.Tensor):
-                    print(f"  {k}: {tuple(v.shape)} {v.dtype} {v.device}", flush=True)
-            import torch.distributed as dist
-            if dist.is_available() and dist.is_initialized():
-                dist.destroy_process_group()
-            raise SystemExit(0)
-
         stack_out = model(src_input, tgt_input)
         total_loss = stack_out['loss']
-
-        if getattr(args, "probe_forward", False) and step == 0:
-            import torch.distributed as dist
-            if dist.is_available() and dist.is_initialized():
-                dist.destroy_process_group()
-            raise SystemExit(0)
 
         model.backward(total_loss)
         model.step()

--- a/script/train_stage2.sh
+++ b/script/train_stage2.sh
@@ -34,8 +34,6 @@ fi
 
 ARGS=(
   --stage 2
-  --task ISLR
-  --dataset WLASL
   --labels     "$LABELS"
   --output_dir "$SAVE"
   --device    cuda


### PR DESCRIPTION
## Summary
- ensure `train_one_epoch` runs through the full dataloader without early debug exits
- drop unsupported `--task` and `--dataset` flags from `train_stage2.sh` so the script only passes valid arguments

## Testing
- `bash script/train_stage2.sh` *(fails: dependency installation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68a3871415f0832e92225ce5980f0886